### PR TITLE
Fix client component build and escape text

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -1,5 +1,5 @@
-// src/App.js
 "use client";
+// src/App.js
 import React from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 

--- a/app/user-onboarding/user-onboared.js
+++ b/app/user-onboarding/user-onboared.js
@@ -36,7 +36,7 @@ const Step4 = () => {
   return (
     <div className="create-container">
       <div className="final-content">
-        <h1 className="page-title final-title">Let's Get to Work – Safely</h1>
+        <h1 className="page-title final-title">Let&apos;s Get to Work – Safely</h1>
         <p className="subtitle final-subtitle">
           All set! Your SafePoint account is good to go.
         </p>


### PR DESCRIPTION
## Summary
- ensure `app/page.js` is treated as a client component by moving the `"use client"` directive to the first line
- escape apostrophe in onboarding final page so eslint passes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6844d83aa24c832a8471ae990dbe9c1f